### PR TITLE
Fixed missing check when applying state to top level of tree

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -68,7 +68,9 @@ export const applyState = (
 	};
 
 	data.forEach((nodeData, index) => {
-		walk(nodeData, state[index]);
+		if (typeof state[index] !== 'undefined') {
+			walk(nodeData, state[index]);
+		}
 	});
 };
 


### PR DESCRIPTION
This adds a missing check when applying state to the top level of the tree. It's already present for all subnodes (see l.64-66). Not having this check caused the library to throw a Typeerror when a node was added to the toplevel and the tree recreated. 