### PR TITLE
Fix typo in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ const tree = new SortableTree({
 
 ### CDN and Browser
 
-In order to use this package in a browser just load add the following tags to your `<head>` section:
+In order to use this package in a browser just add the following tags to your `<head>` section:
 
 ```html
 <script src="https://unpkg.com/sortable-tree/dist/sortable-tree.js"></script>


### PR DESCRIPTION
Remove the word 'load' from the CDN instructions